### PR TITLE
Reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,31 @@
-FROM kennethreitz/pipenv 
-COPY . /app
+FROM python:3.7-alpine
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV LC_ALL C.UTF-8
+ENV LANG C.UTF-8
+
+RUN pip install pipenv
+
+RUN apk update \
+    && apk --no-cache add \
+        gcc \
+        libressl-dev \
+        libffi-dev \
+        postgresql-dev \
+        musl-dev
+
+# -- Install Application into container:
+RUN set -ex && mkdir /app
+
 WORKDIR /app
 
-ENTRYPOINT ["python3", "manager.py"]
+# -- Adding Pipfiles
+COPY Pipfile Pipfile
+COPY Pipfile.lock Pipfile.lock
+
+# -- Install dependencies:
+RUN set -ex && pipenv install --deploy --system
+
+COPY . /app
+
+ENTRYPOINT ["python", "manager.py"]


### PR DESCRIPTION
This PR reduces the docker image size from ~430mb to ~290mb by using alpine-linux as base image. Resolves #8.