### PR TITLE
Wait until worker threshold is reached before provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@
 [![](https://img.shields.io/docker/automated/jrottenberg/ffmpeg.svg)](https://hub.docker.com/r/bakdata/citus-k8s-membership-manager)
 
 
-This project aims to provide a service which helps running PostgreSQL with the [Citus'](https://github.com/citusdata/citus) extension on kubernetes.
+This project aims to provide a service which helps running PostgreSQL with the [Citus](https://github.com/citusdata/citus) extension on kubernetes.
 
 Hereby, it supports the following features:
 
 - Register/unregister worker nodes on master during startup/teardown
+- Wait until worker threshold is reached before provisioning
 - Running provision scripts (SQL) on master/worker node startup
 
 ## Setup
@@ -83,6 +84,12 @@ env:
   value: <default: 5432> # Database port for postgres db
 - name: PG_PASSWORD
   value: <default: None> # If present it is used for all the connections to the pg nodes
+- name: MASTER_PROVISION_FILE
+  value: <default: /etc/config/master.setup> # File path for the master provision script
+- name: WORKER_PROVISION_FILE
+  value: <default: /etc/config/worker.setup> # File path for the worker provision script
+- name: MINIMUM_WORKERS
+  value: <default: 0> # Threshold until the manager waits with node provisioning
 ```
 
 ## Development

--- a/env_conf.py
+++ b/env_conf.py
@@ -19,6 +19,7 @@ class EnvConf:
     pg_port: int
     master_provision_file: str
     worker_provision_file: str
+    minimum_workers: int
 
 
 def parse_env_vars() -> EnvConf:
@@ -35,6 +36,7 @@ def parse_env_vars() -> EnvConf:
         int(env.get("PG_PORT", 5432)),
         env.get("MASTER_PROVISION_FILE", "/etc/config/master.setup"),
         env.get("WORKER_PROVISION_FILE", "/etc/config/worker.setup"),
+        int(env.get("MINIMUM_WORKERS", 0)),
     )
     log.info("Environment Config: %s", conf)
     return conf

--- a/manager.py
+++ b/manager.py
@@ -106,7 +106,10 @@ class Manager:
 
     def add_master(self, pod_name: str) -> None:
         self.citus_master_nodes.add(pod_name)
-        self.provision_node(self.master_provision, pod_name, self.conf.master_service)
+        if len(self.citus_worker_nodes) >= self.conf.minimum_workers:
+            self.provision_node(
+                self.master_provision, pod_name, self.conf.master_service
+            )
         log.info("Registering new master %s", pod_name)
         for worker_pod in self.citus_worker_nodes:
             self.add_worker(worker_pod)
@@ -116,7 +119,10 @@ class Manager:
 
     def add_worker(self, pod_name: str) -> None:
         self.citus_worker_nodes.add(pod_name)
-        self.provision_node(self.worker_provision, pod_name, self.conf.worker_service)
+        if len(self.citus_worker_nodes) >= self.conf.minimum_workers:
+            self.provision_node(
+                self.worker_provision, pod_name, self.conf.worker_service
+            )
         self.exec_on_masters("SELECT master_add_node(%(host)s, %(port)s)", pod_name)
         log.info("Registered worker %s", pod_name)
 

--- a/manager.py
+++ b/manager.py
@@ -46,7 +46,7 @@ class Manager:
 
     def load_config_maps(self) -> typing.Tuple[typing.List[str], typing.List[str]]:
         def read_config(path: str) -> typing.List["str"]:
-            with open(self.conf.master_provision_file, "r") as f:
+            with open(path, "r") as f:
                 return f.readlines()
 
         return (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,6 +109,7 @@ def _configure_manager_pod_template(manager_conf: dict) -> None:
     template["containers"][0]["image"] = MANAGER_NAME
     template["containers"][0]["env"] = []
     template["containers"][0]["env"].append({"name": "NAMESPACE", "value": NAMESPACE})
+    template["containers"][0]["env"].append({"name": "MINIMUM_WORKERS", "value": "2"})
 
     template["containers"][0]["volumeMounts"][0]["name"] = CONFIG_VOLUME
     template["containers"][0]["volumeMounts"][0]["mountPath"] = CONFIG_PATH

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -37,9 +37,10 @@ def stop_provisioning(kubernetes_client):
 
 def test_wait_for_workers_before_provisioning(stop_provisioning):
     @retrying.retry(
-        stop_max_delay=MAX_TIMEOUT,
-        wait_fixed=1 * 1000,
-        retry_on_exception=lambda e: isinstance(e, UnboundLocalError),
+        stop_max_attempt_number=20,
+        wait_fixed=1000,
+        retry_on_exception=lambda e: isinstance(e, UnboundLocalError)
+        or isinstance(e, ProcessLookupError),
     )
     def check_provisioning(pod_name: str):
         with PortForwarder(pod_name, (5435, 5432), NAMESPACE):

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -36,7 +36,11 @@ def stop_provisioning(kubernetes_client):
 
 
 def test_wait_for_workers_before_provisioning(stop_provisioning):
-    @retrying.retry(retry_on_exception=lambda e: isinstance(e, UnboundLocalError))
+    @retrying.retry(
+        stop_max_delay=MAX_TIMEOUT,
+        wait_fixed=1 * 1000,
+        retry_on_exception=lambda e: isinstance(e, UnboundLocalError),
+    )
     def check_provisioning(pod_name: str):
         with PortForwarder(pod_name, (5435, 5432), NAMESPACE):
             with pytest.raises(psycopg2.ProgrammingError):

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -43,17 +43,17 @@ def test_wait_for_workers_before_provisioning(kubernetes_client):
 
 
 def test_node_provisioning_with_configmap():
-    query = "SELECT one();"
-
-    def check_query_result(pod_name: str) -> None:
+    def check_query_result(pod_name: str, query: str, result: int) -> None:
         with PortForwarder(pod_name, (5435, 5432), NAMESPACE):
-            assert 1 == _run_local_query(query, 5435)[0][0]
+            assert result == _run_local_query(query, 5435)[0][0]
 
     @retrying.retry(stop_max_delay=MAX_TIMEOUT, wait_fixed=1 * 1000)
     def check_provisioning() -> None:
-        check_query_result(MASTER_NAME + "-0")
+        master_query = "SELECT one();"
+        check_query_result(MASTER_NAME + "-0", master_query, 1)
+        worker_query = "SELECT two();"
         for i in range(WORKER_COUNT):
-            check_query_result(WORKER_NAME + "-{}".format(i))
+            check_query_result(WORKER_NAME + "-{}".format(i), worker_query, 2)
 
     check_provisioning()
 

--- a/tests/test_yaml/provision-map.yaml
+++ b/tests/test_yaml/provision-map.yaml
@@ -7,4 +7,4 @@ data:
     CREATE FUNCTION one() RETURNS integer AS 'select 1;' LANGUAGE SQL;
   worker.setup: |
     CREATE ERROR; |
-    CREATE FUNCTION one() RETURNS integer AS 'select 1;' LANGUAGE SQL;
+    CREATE FUNCTION two() RETURNS integer AS 'select 2;' LANGUAGE SQL;


### PR DESCRIPTION
In addition to the functionality described above this PR fixes the incorrect loading of the worker provision and adds the new environment config in the README.

Closes #17 