### PR TITLE
Omit unnecessary host postfix on configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ env:
   value: <default: 5432> # Database port for postgres db
 - name: PG_PASSWORD
   value: <default: None> # If present it is used for all the connections to the pg nodes
+- name: SHORT_URL
+  value: <default: False> # If set {pod_name}.{service_name} is used as host pattern instead of {pod_name}.{service_name}.{namespace}.svc.cluster.local
 ```
 
 ## Development

--- a/db.py
+++ b/db.py
@@ -13,6 +13,7 @@ class DBHandler:
     def __init__(self, conf: EnvConf) -> None:
         self.pg_params = self.get_pg_connection_parameters(conf)
         self.namespace = conf.namespace
+        self.short_url = conf.short_url
 
     @staticmethod
     def get_pg_connection_parameters(conf: EnvConf) -> dict:
@@ -43,6 +44,9 @@ class DBHandler:
             connection.close()
 
     def get_host_name(self, pod_name: str, service_name: str) -> str:
+        if self.short_url:
+            host_pattern = "{pod_name}.{service_name}"
+            return host_pattern.format(pod_name=pod_name, service_name=service_name)
         host_pattern = "{pod_name}.{service_name}.{namespace}.svc.cluster.local"
         return host_pattern.format(
             pod_name=pod_name, namespace=self.namespace, service_name=service_name

--- a/env_conf.py
+++ b/env_conf.py
@@ -19,6 +19,7 @@ class EnvConf:
     pg_port: int
     master_provision_file: str
     worker_provision_file: str
+    short_url: bool
 
 
 def parse_env_vars() -> EnvConf:
@@ -35,6 +36,7 @@ def parse_env_vars() -> EnvConf:
         int(env.get("PG_PORT", 5432)),
         env.get("MASTER_PROVISION_FILE", "/etc/config/master.setup"),
         env.get("WORKER_PROVISION_FILE", "/etc/config/worker.setup"),
+        bool(env.get("SHORT_URL", False)),
     )
     log.info("Environment Config: %s", conf)
     return conf

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,6 +109,7 @@ def _configure_manager_pod_template(manager_conf: dict) -> None:
     template["containers"][0]["image"] = MANAGER_NAME
     template["containers"][0]["env"] = []
     template["containers"][0]["env"].append({"name": "NAMESPACE", "value": NAMESPACE})
+    template["containers"][0]["env"].append({"name": "SHORT_URL", "value": "True"})
 
     template["containers"][0]["volumeMounts"][0]["name"] = CONFIG_VOLUME
     template["containers"][0]["volumeMounts"][0]["mountPath"] = CONFIG_PATH


### PR DESCRIPTION
Introduces `SHORT_URL` as environment variable which allows the usage of `{pod_name}.{service_name}` as host pattern for the nodes.

Closes #18.