### PR TITLE
Pass sslmode as connection parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ env:
   value: <default: 0> # Threshold until the manager waits with node provisioning
 - name: SHORT_URL
   value: <default: False> # If set {pod_name}.{service_name} is used as host pattern instead of {pod_name}.{service_name}.{namespace}.svc.cluster.local
+- name: SSL_MODE
+  value: <default: None> # Supports PostgreSQL sslmodes https://www.postgresql.org/docs/current/libpq-ssl.html
 ```
 
 ## Development

--- a/db.py
+++ b/db.py
@@ -21,9 +21,13 @@ class DBHandler:
             "dbname": conf.pg_db,
             "user": conf.pg_user,
             "password": conf.pg_password,
+            "sslmode": conf.ssl_mode,
         }
-        if not parameters["password"]:
-            parameters.pop("password")
+        optionals = ("password", "sslmode")
+        for option in optionals:
+            if parameters[option]:
+                continue
+            parameters.pop(option)
         return parameters
 
     @contextmanager

--- a/env_conf.py
+++ b/env_conf.py
@@ -21,6 +21,7 @@ class EnvConf:
     worker_provision_file: str
     minimum_workers: int
     short_url: bool
+    ssl_mode: str
 
 
 def parse_env_vars() -> EnvConf:
@@ -39,6 +40,7 @@ def parse_env_vars() -> EnvConf:
         env.get("WORKER_PROVISION_FILE", "/etc/config/worker.setup"),
         int(env.get("MINIMUM_WORKERS", 0)),
         bool(env.get("SHORT_URL", False)),
+        env.get("SSL_MODE", ""),
     )
     log.info("Environment Config: %s", conf)
     return conf


### PR DESCRIPTION
This PR allows users to set the PostgreSQL supported `sslmode` enabling the manager to use SSL encrypted connections.

Resolves #23