### PR TITLE
Reduce setup complexity

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,6 @@ env:
   value: <default: 5432> # Database port for postgres db
 - name: PG_PASSWORD
   value: <default: None> # If present it is used for all the connections to the pg nodes
-- name: MASTER_PROVISION_FILE
-  value: <default: /etc/config/master.setup> # File path for the master provision script
-- name: WORKER_PROVISION_FILE
-  value: <default: /etc/config/worker.setup> # File path for the worker provision script
 - name: MINIMUM_WORKERS
   value: <default: 0> # Threshold until the manager waits with node provisioning
 - name: SHORT_URL

--- a/config_monitor.py
+++ b/config_monitor.py
@@ -16,11 +16,13 @@ class ConfigMonitor:
         self,
         conf: EnvConf,
         db_handler: DBHandler,
-        workers: typing.Set[str],
         masters: typing.Set[str],
+        workers: typing.Set[str],
+        master_provision_file: str,
+        worker_provision_file: str,
     ) -> None:
-        self.master_provision_path = conf.master_provision_file
-        self.worker_provision_path = conf.worker_provision_file
+        self.master_provision_path = master_provision_file
+        self.worker_provision_path = worker_provision_file
         self.master_service = conf.master_service
         self.worker_service = conf.worker_service
         self.db_handler = db_handler

--- a/env_conf.py
+++ b/env_conf.py
@@ -17,8 +17,6 @@ class EnvConf:
     pg_user: str
     pg_password: str
     pg_port: int
-    master_provision_file: str
-    worker_provision_file: str
     minimum_workers: int
     short_url: bool
 
@@ -35,8 +33,6 @@ def parse_env_vars() -> EnvConf:
         env.get("PG_USER", "postgres"),
         env.get("PG_PASSWORD", ""),
         int(env.get("PG_PORT", 5432)),
-        env.get("MASTER_PROVISION_FILE", "/etc/citus-config/master.setup"),
-        env.get("WORKER_PROVISION_FILE", "/etc/citus-config/worker.setup"),
         int(env.get("MINIMUM_WORKERS", 0)),
         bool(env.get("SHORT_URL", False)),
     )

--- a/env_conf.py
+++ b/env_conf.py
@@ -35,8 +35,8 @@ def parse_env_vars() -> EnvConf:
         env.get("PG_USER", "postgres"),
         env.get("PG_PASSWORD", ""),
         int(env.get("PG_PORT", 5432)),
-        env.get("MASTER_PROVISION_FILE", "/etc/config/master.setup"),
-        env.get("WORKER_PROVISION_FILE", "/etc/config/worker.setup"),
+        env.get("MASTER_PROVISION_FILE", "/etc/citus-config/master.setup"),
+        env.get("WORKER_PROVISION_FILE", "/etc/citus-config/worker.setup"),
         int(env.get("MINIMUM_WORKERS", 0)),
         bool(env.get("SHORT_URL", False)),
     )

--- a/manager-deployment.yaml
+++ b/manager-deployment.yaml
@@ -18,8 +18,8 @@ spec:
         image: bakdata/citus-k8s-membership-manager:v0.2
         imagePullPolicy: Always
         volumeMounts:
-        - name: <your-volume-name>
-          mountPath: <your-config-path>
+        - name: citus-config-mount
+          mountPath: /etc/citus-config
         resources:
           requests:
             cpu: 100m
@@ -28,6 +28,6 @@ spec:
         - name: NAMESPACE
           value: <your-namespace> 
       volumes:
-      - name: <your-volume-name>
+      - name: citus-config-mount
         configMap:
           name: <your-config-map-name>

--- a/manager.py
+++ b/manager.py
@@ -24,6 +24,8 @@ log = logging.getLogger(__file__)
 
 class Manager:
     def __init__(self) -> None:
+
+        config_path = "/etc/citus-config/"
         self.conf = parse_env_vars()
         self.db_handler = DBHandler(self.conf)
         self.init_provision = False
@@ -44,7 +46,12 @@ class Manager:
             },
         }
         self.config_monitor = ConfigMonitor(
-            self.conf, self.db_handler, self.citus_worker_nodes, self.citus_master_nodes
+            self.conf,
+            self.db_handler,
+            self.citus_master_nodes,
+            self.citus_worker_nodes,
+            config_path + "master.setup",
+            config_path + "worker.setup",
         )
         self.config_monitor.start_watchers()
 

--- a/tests/config.py
+++ b/tests/config.py
@@ -12,6 +12,4 @@ YAML_DIR = os.path.dirname(__file__) + "/test_yaml/"
 MANAGER_DEPLOYMENT = os.path.dirname(__file__) + "/../manager-deployment.yaml"
 SERVICE_ACCOUNT = "pod-listing-sa"
 
-CONFIG_VOLUME = "config-volume"
 CONFIG_MAP = "setup-config"
-CONFIG_PATH = "/etc/config"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,8 +15,6 @@ from config import (
     SERVICE_ACCOUNT,
     MANAGER_NAME,
     CONFIG_MAP,
-    CONFIG_PATH,
-    CONFIG_VOLUME,
 )
 from util import run_kubectl_command, parse_single_kubernetes_yaml
 
@@ -111,10 +109,6 @@ def _configure_manager_pod_template(manager_conf: dict) -> None:
     template["containers"][0]["env"].append({"name": "MINIMUM_WORKERS", "value": "2"})
     template["containers"][0]["env"].append({"name": "SHORT_URL", "value": "True"})
 
-    template["containers"][0]["volumeMounts"][0]["name"] = CONFIG_VOLUME
-    template["containers"][0]["volumeMounts"][0]["mountPath"] = CONFIG_PATH
-
-    template["volumes"][0]["name"] = CONFIG_VOLUME
     template["volumes"][0]["configMap"]["name"] = CONFIG_MAP
 
     manager_conf["spec"]["template"]["spec"] = template


### PR DESCRIPTION
This PR should make it easier to deploy the manager and lower the need for prior configuration. 

Following point were addressed:
* Use static volume name
* Use static file names for provision files
* Use static mount directory `/etc/citus-config`

Closes #27 